### PR TITLE
feat(build): ORI-6675 - Ignore summary, meta output for Lefthook

### DIFF
--- a/lefthook.yml
+++ b/lefthook.yml
@@ -1,14 +1,14 @@
 pre-commit:
-  parallel: true
+  piped: true
   commands:
-    commit-msg:
-      run: pnpm commitlint --edit
     nx-affected-format:
       run: pnpm exec nx affected --target=format:write
     nx-affected-lint:
       run: pnpm exec nx affected --target=lint --fix
     nx-affected-spec:
       run: pnpm exec nx affected --target=test --ci --code-coverage
+    conv-commit-msg:
+      run: pnpm commitlint --edit
 
 skip_output:
   - meta

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -7,7 +7,7 @@ pre-commit:
       run: pnpm exec nx affected --target=format:write
     nx-affected-lint:
       run: pnpm exec nx affected --target=lint --fix
-    nx-spec:
+    nx-affected-spec:
       run: pnpm exec nx affected --target=test --ci --code-coverage
 
 skip_output:

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -1,14 +1,16 @@
 pre-commit:
   piped: true
   commands:
-    nx-affected-format:
+    1_nx-affected-format:
       run: pnpm exec nx affected --target=format:write
-    nx-affected-lint:
+    2_nx-affected-lint:
       run: pnpm exec nx affected --target=lint --fix
-    nx-affected-spec:
+    3_nx-affected-spec:
       run: pnpm exec nx affected --target=test --ci --code-coverage
-    conv-commit-msg:
+    4_conv-commit-msg:
       run: pnpm commitlint --edit
 
 skip_output:
+  - summary
+  - success
   - meta


### PR DESCRIPTION
- feat(build): ORI-6675/ Fixes for conv-commit management
- feat(build): ORI-6675/ Lefthook to run piped commands before commiting
- feat(build): ORI-6675/ Lefthook, ignore summary and meta info
